### PR TITLE
Triviality: “punt volant” → “punt volat”

### DIFF
--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@ Frankrijk ijzerwaren RIJKS IJsselmeer <span class="red">→</span> <span class="
 íj ÍJ <span class="red">→</span> <span class="lang" lang="nl">íj ÍJ</span><br><br>
 <em>Turkish dotted i and dotless ı capitalisation</em><br>
 ı i I İ <span class="red"><span class="case">→</span></span> <font style="text-transform: uppercase;"><span class="lang" lang="tr">ı i I İ</span></font><br><br>
-<em>Catalàn punt volant</em><br>
+<em>Catalan punt volat</em><br>
 cel·la CEL·LA <span class="red">→</span> <span id="lang" lang="ca">cel·la CEL·LA</span><br><br>
 </p>
 


### PR DESCRIPTION
While “volant” is, of course, a correct Catalan word,
the interpunct has been given the specific name of “volat”
in that language.

Fixes #1.

(@clauseggers: I should thank you for caring about setting the Catalan interpunct so nicely in your beautiful typeface. :+1:)
